### PR TITLE
test-mmc5883: simplify with abstracted logging

### DIFF
--- a/test-mmc5883.py
+++ b/test-mmc5883.py
@@ -1,27 +1,18 @@
 #!/usr/bin/python3
 
-import argparse
 from mmc5883 import MMC5883
-from pathlib import Path
-import llog
-import time
+from llog import LLogWriter
 
 device = "mmc5883"
-defaultMeta = Path(__file__).resolve().parent / f"{device}.meta"
-
-parser = argparse.ArgumentParser(description=f'{device} test')
-parser.add_argument('--output', action='store', type=str, default=None)
-parser.add_argument('--meta', action='store', type=str, default=defaultMeta)
-parser.add_argument('--frequency', action='store', type=int, default=None)
+parser = LLogWriter.create_default_parser(__file__, device)
 args = parser.parse_args()
 
 
 with llog.LLogWriter(args.meta, args.output) as log:
     mmc = MMC5883()
-
-    while True:
+    
+    def data_getter():
         data = mmc.measure()
-        log.log(llog.LLOG_DATA, f"{data.x_raw} {data.y_raw} {data.z_raw} {data.t_raw} {data.x} {data.y} {data.z} {data.t}")
-        
-        if args.frequency:
-            time.sleep(1.0/args.frequency)
+        return f"{data.x_raw} {data.y_raw} {data.z_raw} {data.t_raw} {data.x} {data.y} {data.z} {data.t}"
+    
+    log.log_data_loop(data_getter, parser_args=args)


### PR DESCRIPTION
Not sure how to properly handle the calibration data and images in the existing report, so have left the report alone for now.